### PR TITLE
フレーキーなテストを改善

### DIFF
--- a/app/views/cards/_card.html.erb
+++ b/app/views/cards/_card.html.erb
@@ -1,4 +1,4 @@
-<div data-controller="memorized-button">
+<div data-controller="memorized-button" id="card-<%= card.id %>">
   <p>和文：<%= link_to card.ja_phrase, card_path(card) %></p>
   <p>英文：<%= link_to card.en_phrase, card_path(card) %></p>
   <%= link_to '編集する', edit_card_path(card) %>

--- a/spec/system/cards_spec.rb
+++ b/spec/system/cards_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe "Cards", type: :system do
     expect(page).to have_content 'Updated card'
   end
 
-  it 'can review unmemorized cards in review mode' do
+  it 'can review unmemorized cards in review mode', :js do
     unmemorized_card1 = FactoryBot.create(:card, :unmemorized1)
     unmemorized_card2 = FactoryBot.create(:card, :unmemorized2)
 
@@ -87,13 +87,16 @@ RSpec.describe "Cards", type: :system do
     expect(page).not_to have_content 'I haven\'t memorized it yet.'
   end
 
-  it 'a memorized button removes card from review mode' do
+  it 'a memorized button removes card from review mode', :js do
     card = FactoryBot.create(:card, :unmemorized1)
     card2 = FactoryBot.create(:card, :unmemorized2)
     visit cards_path
-    expect(page).to have_content 'まだ暗記できていない'
-    expect(page).to have_content 'I haven\'t memorized it yet.'
-    click_on '覚えた！', match: :first
+    expect(page).to have_content 'もう少し。でも、まだ暗記できていない'
+    expect(page).to have_content 'Almost there. But I haven\'t memorized it yet.'
+    within "#card-#{card2.id}" do
+      click_on '覚えた！'
+      expect(page).to have_content("忘れた！", wait: 7)
+    end
     visit review_cards_path
     expect(page).not_to have_content 'もう少し。でも、まだ暗記できていない'
     expect(page).to have_content 'まだ暗記できていない'


### PR DESCRIPTION
`have_content`で最大6秒待つように設定したところ改善した。
継続して落ちるようなら最大待機時間の設定を見直すことも検討する。