### PR TITLE
CIで必ず失敗していたメニュー関係のテストを修正した

### DIFF
--- a/app/views/application/header/_header_links.html.erb
+++ b/app/views/application/header/_header_links.html.erb
@@ -11,7 +11,7 @@
       <button id="menu-close" data-action="dropdown#toggle:stop" class="px-2.5 py-1 bg-blue-500 text-white text-sm rounded">
         <%= image_tag 'hamburger_menu_icon.png', alt: 'hamburger_menu_icon', class: 'hamburger_menu_icon' %>
       </button>
-      <div id="menu-open" data-dropdown-target="menu" class="hidden absolute top-4 right-0 mt-8 flex w-screen max-w-max text-orange-950">
+      <div id="menu-open" data-dropdown-target="menu" class="hidden">
         <%= render 'application/header/menu' %>
       </div>
     </div>

--- a/app/views/application/header/_menu.html.erb
+++ b/app/views/application/header/_menu.html.erb
@@ -1,22 +1,22 @@
-<div class="text-sm bg-white shadow-lg rounded border overflow-hidden w-32">
+<div class="text-sm bg-white shadow-lg rounded border">
   <ul class="header-dropdown__items">
     <li class="header-dropdown__item">
-      <%= link_to 'トップページ', cards_path, class: 'footer-nav__item-link' %>
+      <%= link_to 'トップページ', cards_path, class: 'header-dropdown__item-link' %>
     </li>
     <li class="header-dropdown__item">
       <%= link_to '復習モード', review_cards_path, data: { turbo_prefetch: false } %>
     </li>
     <li class="header-dropdown__item">
-      <%= link_to '利用規約', '', class: 'footer-nav__item-link' %>
+      <%= link_to '利用規約', '', class: 'header-dropdown__item-link' %>
     </li>
     <li class="header-dropdown__item">
-      <%= link_to 'プライバシーポリシー', '', class: 'footer-nav__item-link' %>
+      <%= link_to 'プライバシーポリシー', '', class: 'header-dropdown__item-link' %>
     </li>
     <li class="header-dropdown__item">
-      <%= link_to 'ログアウト', log_out_path, class: 'header-dropdown__item-link logout-button', id: 'logout', data: { turbo_prefetch: false } %>
+      <%= link_to 'ログアウト', log_out_path, class: 'header-dropdown__item-link', data: { turbo_prefetch: false } %>
     </li>
     <li class="header-dropdown__item">
-      <%= link_to '退会', user_path, data: { turbo_method: :delete, turbo_confirm: '退会すると今まで作成したカードは全て削除されます。退会してよろしいですか？', turbo_prefetch: false }, class: 'header-dropdown__item-link', id: 'withdrawal' %>
+      <%= link_to '退会', user_path, data: { turbo_method: :delete, turbo_confirm: '退会すると今まで作成したカードは全て削除されます。退会してよろしいですか？', turbo_prefetch: false }, class: 'header-dropdown__item-link' %>
     </li>
   </ul>
 </div>

--- a/spec/system/cards_spec.rb
+++ b/spec/system/cards_spec.rb
@@ -151,26 +151,4 @@ RSpec.describe "Cards", type: :system do
     expect(page).to have_content('本日は晴天なり', wait: 10)
     expect(page).to have_content('testing a microphone', wait: 10)
   end
-
-  # it 'user can log out', :js do
-  #   click_on 'hamburger_menu_icon'
-  #   expect(page).to have_content('ログアウト', wait: 10)
-  #   within('#menu-open') do
-  #     find_by_id('logout').click
-  #   end
-  #   expect(page).to have_content 'Home#index'
-  #   expect(page).to have_content 'ログアウトしました'
-  # end
-
-  # it 'user can withdrawal', :js do
-  #   click_on 'hamburger_menu_icon'
-  #   expect(page).to have_content('退会', wait: 10)
-  #   within('#menu-open') do
-  #     accept_confirm '退会すると今まで作成したカードは全て削除されます。退会してよろしいですか？' do
-  #       find_by_id('withdrawal').click
-  #     end
-  #   end
-  #   expect(page).to have_content 'Home#index'
-  #   expect(page).to have_content '退会しました'
-  # end
 end

--- a/spec/system/sessions_spec.rb
+++ b/spec/system/sessions_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe "Sessions", type: :system do
+  let(:user) { FactoryBot.create(:user) }
+
+  it 'a user log in', :js do
+    log_in_as user
+    expect(page).to have_content 'ログインしました'
+  end
+
+  it 'a user log out', :js do
+    log_in_as user
+    expect(page).to have_content 'ログインしました'
+    click_on 'hamburger_menu_icon'
+    expect(page).to have_content 'ログアウト'
+    click_on 'ログアウト'
+    expect(page).to have_content 'Home#index'
+    expect(page).to have_content 'ログアウトしました'
+  end
+end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe "Users", type: :system do
+  let(:user) { FactoryBot.create(:user) }
+
+  it 'a user withdrawals', :js do
+    log_in_as user
+    click_on 'hamburger_menu_icon'
+    expect(page).to have_content '退会'
+    accept_confirm '退会すると今まで作成したカードは全て削除されます。退会してよろしいですか？' do
+      click_on '退会'
+    end
+    expect(page).to have_content 'Home#index'
+    expect(page).to have_content '退会しました'
+  end
+end


### PR DESCRIPTION
・ハンバーガーメニューに対してTailwindのoverflow-hiddenを設定してしまっていたことによって、
  メニュー展開時であってもテキストの長さが10文字以下のリンクが非表示扱いになってしまい
  テストに失敗していたため修正した。

・併せて、ハンバーガーメニューのパーシャル内で不揃いだったclassの統一と不要なidの削除を行うとともに、
  ログインとログアウトに関するテストをsessions_specへ、Userに関するテストをusers_specへ移動させた。