### PR TITLE
DOMツリー上で2ページ目以降に含まれるカードも正常に更新できるよう修正した

### DIFF
--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -69,13 +69,10 @@ class CardsController < ApplicationController
   end
 
   def update
-    @card = Card.find(params[:id])
     if @card.update(card_params)
-      respond_to do |format|
-        format.html { redirect_to cards_path, notice: 'Card was successfully updated.' }
-      end
+      flash.now.notice = 'Card was successfully updated.'
     else
-      render :edit
+      render :edit, status: :unprocessable_entity
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,5 @@
 module ApplicationHelper
+  def turbo_stream_flash
+    turbo_stream.update 'flash', partial: 'flash'
+  end
 end

--- a/app/views/application/_flash.html.erb
+++ b/app/views/application/_flash.html.erb
@@ -1,0 +1,7 @@
+<% if notice %>
+  <div class="flash_message" data-controller="flash" data-flash-dismiss-after-value="3000"><%= notice %></div>
+<% end %>
+
+<% if alert %>
+  <div class="flash_message" data-controller="flash" data-flash-dismiss-after-value="3000"><%= alert %></div>
+<% end %>

--- a/app/views/cards/_card.html.erb
+++ b/app/views/cards/_card.html.erb
@@ -1,4 +1,4 @@
-<%= turbo_frame_tag "card_#{card.id}" do %>
+<%= turbo_frame_tag card do %>
   <div data-controller="memorized-button" id="card-<%= card.id %>" class="a-card" >
     <p>和文：<%= link_to card.ja_phrase, card_path(card), data: { turbo_frame: '_top' } %></p>
     <p>英文：<%= link_to card.en_phrase, card_path(card), data: { turbo_frame: '_top' } %></p>

--- a/app/views/cards/edit.html.erb
+++ b/app/views/cards/edit.html.erb
@@ -1,5 +1,5 @@
 <h1>編集</h1>
-<%= turbo_frame_tag "card_#{@card.id}" do %>
+<%= turbo_frame_tag @card do %>
   <%= form_with model: @card do |form| %>
     <%= form.label :ja_phrase, '日本語' %>
     <%= form.text_area :ja_phrase %>

--- a/app/views/cards/update.turbo_stream.erb
+++ b/app/views/cards/update.turbo_stream.erb
@@ -1,0 +1,2 @@
+<%= turbo_stream.replace @card %>
+<%= turbo_stream_flash %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,11 +22,9 @@
     <div class="wrapper is-application">
       <%= render 'application/header/header' %>
     </div>
-    <% flash.each do |message_type, message| %>
-      <div data-controller="flash" data-flash-dismiss-after-value="3000">
-        <div class="flash-message <%= message_type %>"><%= message %></div>
-      </div>
-    <% end %>
+    <div id="flash">
+      <%= render "flash" %>
+    </div>
     <main class="container mx-auto mt-28 px-5 flex">
       <%= yield %>
     </main>


### PR DESCRIPTION
- Resolve #90 

無限スクロール実装に伴い、ページネーションの扱いとしては2ページ目以降に含まれるカードを更新するとTurbo Frameでの画面更新がうまくいかなくなっていたため修正した。