### PR TITLE
プライバシーポリシーと利用規約のページを作った

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,5 +1,11 @@
 class HomeController < ApplicationController
-  skip_before_action :authenticate, only: :index
+  skip_before_action :authenticate
   def index
+  end
+
+  def terms
+  end
+
+  def privacy
   end
 end

--- a/app/views/application/footer/_footer.html.erb
+++ b/app/views/application/footer/_footer.html.erb
@@ -1,0 +1,20 @@
+<hr class="a-border">
+<footer class="footer">
+  <div class="container">
+    <div class="footer__inner">
+      <nav class="footer-nav">
+        <ul class="footer-nav__items">
+          <li class="footer-nav__item">
+            <%= link_to 'トップページ', root_path, class: 'footer-nav__item-link' %>
+          </li>
+          <li class="footer-nav__item">
+            <%= link_to '利用規約', terms_path, class: 'footer-nav__item-link' %>
+          </li>
+          <li class="footer-nav__item">
+            <%= link_to 'プライバシーポリシー', privacy_path, class: 'footer-nav__item-link' %>
+          </li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+</footer>

--- a/app/views/application/header/_menu.html.erb
+++ b/app/views/application/header/_menu.html.erb
@@ -7,10 +7,10 @@
       <%= link_to '復習モード', review_cards_path, data: { turbo_prefetch: false } %>
     </li>
     <li class="header-dropdown__item">
-      <%= link_to '利用規約', '', class: 'header-dropdown__item-link' %>
+      <%= link_to '利用規約', terms_path, class: 'header-dropdown__item-link' %>
     </li>
     <li class="header-dropdown__item">
-      <%= link_to 'プライバシーポリシー', '', class: 'header-dropdown__item-link' %>
+      <%= link_to 'プライバシーポリシー', privacy_path, class: 'header-dropdown__item-link' %>
     </li>
     <li class="header-dropdown__item">
       <%= link_to 'ログアウト', log_out_path, class: 'header-dropdown__item-link', data: { turbo_prefetch: false } %>

--- a/app/views/home/privacy.html.erb
+++ b/app/views/home/privacy.html.erb
@@ -1,0 +1,4 @@
+<div>
+  <h1 class="font-bold text-4xl">プライバシーポリシー</h1>
+  <p>本文</p>
+</div>

--- a/app/views/home/terms.html.erb
+++ b/app/views/home/terms.html.erb
@@ -1,0 +1,4 @@
+<div>
+  <h1 class="font-bold text-4xl">利用規約</h1>
+  <p>本文</p>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -28,5 +28,8 @@
     <main class="container mx-auto mt-28 px-5 flex">
       <%= yield %>
     </main>
+    <div class="footer">
+      <%= render 'application/footer/footer' %>
+    </div>
   </body>
 </html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,4 +25,6 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   # root "posts#index"
+  get 'terms', to: 'home#terms'
+  get 'privacy', to: 'home#privacy'
 end

--- a/spec/system/home_spec.rb
+++ b/spec/system/home_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe "Cards", type: :system do
+  let(:user) { FactoryBot.create(:user) }
+
+  describe 'not logged in' do
+    it 'visit terms page', :js do
+      visit root_path
+      click_on '利用規約'
+      expect(page).to have_css 'h1', text: '利用規約'
+    end
+
+    it 'visit privacy policy page', :js do
+      visit root_path
+      click_on 'プライバシーポリシー'
+      expect(page).to have_css 'h1', text: 'プライバシーポリシー'
+    end
+  end
+
+  describe 'logged in', :js do
+    before do
+      log_in_as user
+    end
+
+    it 'visit terms page', :js do
+      expect(page).to have_content 'ログインしました'
+      click_on 'hamburger_menu_icon'
+      within('#menu-open') do
+        click_on '利用規約'
+      end
+      expect(page).to have_css 'h1', text: '利用規約'
+    end
+
+    it 'visit privacy policy page', :js do
+      expect(page).to have_content 'ログインしました'
+      click_on 'hamburger_menu_icon'
+      within('#menu-open') do
+      click_on 'プライバシーポリシー'
+      end
+      expect(page).to have_css 'h1', text: 'プライバシーポリシー'
+    end
+  end
+end


### PR DESCRIPTION
- Resolve #86 #87 #12 

プライバシーポリシー及び利用規約のページを作成した。
中身は後日作成のうえ反映させる予定。
なお、無限スクロールの実装に伴いフッターを廃止していたが、未ログイン状態の場合はフッターにプライバシーポリシーや利用規約のリンクを置いておきたいこと、そもそもフッターの存在はカード一覧ページの無限スクロール機能と競合しないなどの理由からフッターを復活させた。