### PR TITLE
カード編集画面のキャンセルボタンの不具合を修正した

### DIFF
--- a/app/views/cards/edit.html.erb
+++ b/app/views/cards/edit.html.erb
@@ -8,6 +8,6 @@
     <div>
       <%= form.submit '更新する' %>
     </div>
-  <%= link_to 'キャンセル', cards_path %>
+  <%= link_to 'キャンセル', @card %>
   <% end %>
 <% end %>

--- a/app/views/cards/show.html.erb
+++ b/app/views/cards/show.html.erb
@@ -1,6 +1,7 @@
 <div>
   <h1 class="font-bold text-4xl">Cards#show</h1>
-  <p>和文：<%= @card.ja_phrase %></p>
-  <p>英文：<%= @card.en_phrase %></p>
+  <div>
+    <%= render partial: 'card', locals: { card: @card } %>
+  </div>
   <%= link_to '削除する', card_path(@card), data: { turbo_method: :delete, turbo_confirm: '本当に削除しますか？' } %>
 </div>


### PR DESCRIPTION
・カードの編集画面をキャンセルボタンで閉じようとするとTurboが適切なパーシャルを見つけることができずにContent Missingになってしまう不具合があったため修正した。
`cards/show.html.erb`に適切な`turbo_frame_tag`が記載できていなかったことが原因だった。