### PR TITLE
カード詳細ページから削除を実行した場合にカード一覧画面へ遷移するように変更した

### DIFF
--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -56,13 +56,20 @@ class CardsController < ApplicationController
   def destroy
     @card = Card.find(params[:id])
     @card.destroy
+    flash.now.notice = '削除しました'
+
     respond_to do |format|
-      format.html { redirect_to cards_path, notice: '削除しました', status: :see_other }
+      if params[:from_show]
+        format.html { redirect_to cards_path, notice: 'カードを削除しました' }
+      else
+        format.turbo_stream
+      end
     end
   end
 
   def edit
     @card = Card.find(params[:id])
+    @from_show = params[:from_show]
   end
 
   def update

--- a/app/views/cards/_card.html.erb
+++ b/app/views/cards/_card.html.erb
@@ -12,7 +12,7 @@
         </div>
       </div>
       <div class="edit-button w-full h-[2rem] flex justify-center border-2 border-solid border-[#aaaaaa] text-lg">
-        <%= link_to '編集する', edit_card_path(card), data: { turbo_frame: dom_id(card) }, class: "flex justify-center w-full h-full"%>
+        <%= link_to '編集する', edit_card_path(card, local_assigns[:from_show] ? { from_show: from_show } : nil), data: { turbo_frame: dom_id(card) }, class: "flex justify-center w-full h-full"%>
       </div>
     </div>
     <div class="memorized-button-wrapper flex flex-row-reverse items-center ml-4 mb-8 w-1/6">

--- a/app/views/cards/destroy.turbo_stream.erb
+++ b/app/views/cards/destroy.turbo_stream.erb
@@ -1,0 +1,2 @@
+<%= turbo_stream.remove @card %>
+<%= turbo_stream_flash %>

--- a/app/views/cards/edit.html.erb
+++ b/app/views/cards/edit.html.erb
@@ -17,6 +17,11 @@
         <div class="cancel-button w-full h-[2rem] flex justify-center border-2 border-solid border-[#aaaaaa] text-lg">
           <%= link_to 'キャンセル', @card, class: "w-full h-full flex justify-center items-center cursor-pointer" %>
         </div>
+        <div class="delete-button w-full h-[2rem] flex justify-center border-2 border-solid border-[#aaaaaa] text-lg">
+          <%= link_to '削除する', card_path(@card, @from_show ? { from_show: @from_show } : nil),
+                                  data: { turbo_method: :delete, turbo_confirm: '本当に削除しますか？', turbo_frame: '_top' },
+                                  class: "w-full h-full flex justify-center items-center cursor-pointer" %>
+        </div>
       </div>
     </div>
   <% end %>

--- a/app/views/cards/show.html.erb
+++ b/app/views/cards/show.html.erb
@@ -1,30 +1,4 @@
   <h1 class="flex justify-center font-bold text-4xl my-8">詳細</h1>
-<%= turbo_frame_tag @card do %>
-  <div id="card-<%= @card.id %>" class="flex flex-row mb-8">
-    <div class="a-card-container flex flex-col w-full">
-      <div class="a-card h-24 w-full flex justify-between border-2 border-solid border-[#aaaaaa] rounded-md mb-2">
-        <div class="phrase-pair w-full grid justify-items-center divide-y-2 divide-[#b0b0b0] divide-dashed">
-          <div class="ja-phrase grid content-center w-full">
-            <p>・<%= link_to @card.ja_phrase, card_path(@card), data: { turbo_frame: '_top' } %></p>
-          </div>
-          <div class="en-phrase grid content-center w-full">
-            <p>・<%= link_to @card.en_phrase, card_path(@card), data: { turbo_frame: '_top' } %></p>
-          </div>
-        </div>
-      </div>
-      <div class="edit-button w-full h-[2rem] flex justify-center border-2 border-solid border-[#aaaaaa] text-lg">
-        <%= link_to '編集する', edit_card_path(@card, from_show: true), data: { turbo_frame: dom_id(@card) }, class: "flex justify-center w-full h-full"%>
-      </div>
-    </div>
-    <div class="memorized-button-wrapper flex flex-row-reverse items-center ml-4 mb-8 w-1/6">
-      <div data-controller="memorized-button" class="memorized-button flex justify-center h-[2rem] w-full border-2 border-solid border-[#aaaaaa]">
-        <%= link_to @card.memorized_at.nil? ? '覚えた！' : '忘れた！',
-                    update_memorized_status_card_path(@card),
-                    data: { turbo_method: :patch,
-                            memorized_button_target: 'memorizedButton',
-                            action: 'click->memorized-button#switchText' },
-                    class: "flex justify-center items-center w-full h-full" %>
-      </div>
-    </div>
+  <div>
+    <%= render partial: 'card', locals: { card: @card, from_show: true } %>
   </div>
-<% end %>

--- a/app/views/cards/show.html.erb
+++ b/app/views/cards/show.html.erb
@@ -1,7 +1,30 @@
-<div>
-  <h1 class="font-bold text-4xl">Cards#show</h1>
-  <div>
-    <%= render partial: 'card', locals: { card: @card } %>
+  <h1 class="flex justify-center font-bold text-4xl my-8">詳細</h1>
+<%= turbo_frame_tag @card do %>
+  <div id="card-<%= @card.id %>" class="flex flex-row mb-8">
+    <div class="a-card-container flex flex-col w-full">
+      <div class="a-card h-24 w-full flex justify-between border-2 border-solid border-[#aaaaaa] rounded-md mb-2">
+        <div class="phrase-pair w-full grid justify-items-center divide-y-2 divide-[#b0b0b0] divide-dashed">
+          <div class="ja-phrase grid content-center w-full">
+            <p>・<%= link_to @card.ja_phrase, card_path(@card), data: { turbo_frame: '_top' } %></p>
+          </div>
+          <div class="en-phrase grid content-center w-full">
+            <p>・<%= link_to @card.en_phrase, card_path(@card), data: { turbo_frame: '_top' } %></p>
+          </div>
+        </div>
+      </div>
+      <div class="edit-button w-full h-[2rem] flex justify-center border-2 border-solid border-[#aaaaaa] text-lg">
+        <%= link_to '編集する', edit_card_path(@card, from_show: true), data: { turbo_frame: dom_id(@card) }, class: "flex justify-center w-full h-full"%>
+      </div>
+    </div>
+    <div class="memorized-button-wrapper flex flex-row-reverse items-center ml-4 mb-8 w-1/6">
+      <div data-controller="memorized-button" class="memorized-button flex justify-center h-[2rem] w-full border-2 border-solid border-[#aaaaaa]">
+        <%= link_to @card.memorized_at.nil? ? '覚えた！' : '忘れた！',
+                    update_memorized_status_card_path(@card),
+                    data: { turbo_method: :patch,
+                            memorized_button_target: 'memorizedButton',
+                            action: 'click->memorized-button#switchText' },
+                    class: "flex justify-center items-center w-full h-full" %>
+      </div>
+    </div>
   </div>
-  <%= link_to '削除する', card_path(@card), data: { turbo_method: :delete, turbo_confirm: '本当に削除しますか？' } %>
-</div>
+<% end %>

--- a/spec/system/cards_spec.rb
+++ b/spec/system/cards_spec.rb
@@ -34,9 +34,9 @@ RSpec.describe "Cards", type: :system do
 
   it 'display a details page of cards', :js do
     visit cards_path
-    expect(page).to have_content "フレーズ一覧"
+    expect(page).to have_content 'フレーズ一覧'
     click_on cards[0].ja_phrase
-    expect(page).to have_content 'Cards#show'
+    expect(page).to have_content '詳細'
     expect(page).to have_content cards[0].ja_phrase
     expect(page).to have_content cards[0].en_phrase
     expect(page).not_to have_content cards[1].ja_phrase
@@ -47,11 +47,12 @@ RSpec.describe "Cards", type: :system do
     visit card_path(cards[0])
     expect(page).to have_content cards[0].ja_phrase
     expect(page).to have_content cards[0].en_phrase
-    expect(page).to have_content 'Cards#show'
+    expect(page).to have_content '詳細'
+    click_on '編集する'
     accept_confirm "本当に削除しますか？" do
       click_on '削除する'
     end
-    expect(page).to have_content 'フレーズ一覧'
+    expect(page).to have_content('フレーズ一覧', wait: 10)
     expect(page).not_to have_content cards[0].ja_phrase
     expect(page).not_to have_content cards[0].en_phrase
   end


### PR DESCRIPTION
- Resolve #98 

元々`_card.html.erb`を参照していたためデザインに大きな変更はないが、詳細画面から削除を実行した際にすでに削除済みのカード詳細画面に留まってしまっていたため、カード一覧へ遷移できるよう調整した。