### PR TITLE
カード新規作成時のturbo_streamの処理を修正した

### DIFF
--- a/app/views/cards/create.turbo_stream.erb
+++ b/app/views/cards/create.turbo_stream.erb
@@ -1,3 +1,5 @@
 <%= turbo_stream.prepend 'cards', partial: 'cards/card', locals: { card: @card } %>
-<%= turbo_stream.update Card.new, '' %>
+<%= turbo_stream.replace Card.new do %>
+  <%= turbo_frame_tag Card.new, class: "flex flex-col justify-center h-[400px] w-2/3 fixed top-0 left-50 hidden", data: { "creation-form-target": "creationForm" } %>
+<% end %>
 <%= turbo_stream_flash %>


### PR DESCRIPTION
・新規作成後、フォームの要素が画面上に残ってしまい、その背面にある要素がクリックできなくなる不具合があったため修正した。
- Resolve #105 
