### PR TITLE
復習モード画面のレイアウトとデザインを調整した

### DIFF
--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -81,7 +81,7 @@ class CardsController < ApplicationController
   end
 
   def review
-    cards = Card.unmemorized.order(created_at: :desc)
+    cards = current_user.cards.unmemorized.order(created_at: :desc)
     if params[:id]
       @card = Card.find(params[:id])
       @next_card = cards.where('id < ?', @card.id).first

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,4 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
 import "@hotwired/turbo-rails";
 import "controllers";
+import "fontawesome";

--- a/app/javascript/controllers/review_controller.js
+++ b/app/javascript/controllers/review_controller.js
@@ -4,12 +4,15 @@ import { Controller } from "@hotwired/stimulus";
 export default class extends Controller {
   static targets = ["enPhrase", "switchingButton"];
   switchEnPhraseVisibility() {
-    this.enPhraseTarget.style.display =
-      this.enPhraseTarget.style.display === "none" ? "block" : "none";
+    if (this.enPhraseTarget.classList.contains("hidden")) {
+      this.enPhraseTarget.classList.remove("hidden");
+    } else {
+      this.enPhraseTarget.classList.add("hidden");
+    }
 
     this.switchingButtonTarget.textContent =
-      this.switchingButtonTarget.textContent === "英文を表示する"
+      this.switchingButtonTarget.textContent === "英文を表示"
         ? "英文を隠す"
-        : "英文を表示する";
+        : "英文を表示";
   }
 }

--- a/app/views/cards/review.html.erb
+++ b/app/views/cards/review.html.erb
@@ -1,15 +1,50 @@
 <div data-controller="review">
-  <h1 class="font-bold text-4xl">復習モード</h1>
-  <button data-review-target="switchingButton" data-action="click->review#switchEnPhraseVisibility">英文を表示する</button>
-  <p>和文：<%= @card.ja_phrase %></p>
-  <p data-review-target="enPhrase" style="display: none">英文：<%= @card.en_phrase %></p>
-  <%= link_to '削除する', card_path(@card), data: { turbo_method: :delete, turbo_confirm: '本当に削除しますか？' } %>
-  <% if @next_card %>
-    <%= link_to '次のカードへ', review_cards_path(id: @next_card.id) %>
-  <% end %>
-
-  <% if @previous_card %>
-    <%= link_to '前のカードへ', review_cards_path(id: @previous_card.id) %>
-  <% end %>
+  <h1 class="font-bold text-4xl flex justify-center font-bold text-4xl my-8">復習モード</h1>
+  <div class="change-visibility-button my-4 flex justify-end mx-8">
+    <button data-review-target="switchingButton" data-action="click->review#switchEnPhraseVisibility" class="inline-flex h-8 w-32 items-center justify-center rounded-full bg-[#6791d1] px-6 font-medium text-[#fafafa]">英文を表示</button>
+  </div>
+  <div id="card-<%= @card.id %>" class="flex flex-col items-center mb-4 mx-8">
+    <div class="a-card-container flex flex-col w-full">
+      <div class="a-card h-24 w-full flex justify-between border-2 border-solid border-[#aaaaaa] rounded-md mb-2">
+        <div class="phrase-pair w-full grid justify-items-center divide-y-2 divide-[#b0b0b0] divide-dashed">
+          <div class="ja-phrase grid content-center w-full flex justify-center">
+            <p>・<%= link_to @card.ja_phrase, card_path(@card), data: { turbo_frame: '_top' } %></p>
+          </div>
+          <div data-review-target="enPhrase" class="en-phrase grid content-center w-full hidden flex justify-center">
+            <p>・<%= link_to @card.en_phrase, card_path(@card), data: { turbo_frame: '_top' } %></p>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="memorized-button-wrapper flex flex-row-reverse items-center w-1/3">
+      <div data-controller="memorized-button" class="memorized-button flex justify-center h-[2rem] w-full border-2 border-solid border-[#aaaaaa] bg-[#FADC75]">
+        <%= link_to @card.memorized_at.nil? ? '覚えた！' : '忘れた！',
+                    update_memorized_status_card_path(@card),
+                    data: { turbo_method: :patch,
+                            memorized_button_target: 'memorizedButton',
+                            action: 'click->memorized-button#switchText' },
+                    class: "flex justify-center items-center w-full h-full text-base" %>
+      </div>
+    </div>
+  </div>
+  <div class="pagination-links flex justify-between mb-8 mx-8">
+    <div class="w-40">
+      <% if @previous_card %>
+        <div class="previous-page inline-flex h-8 w-full items-center justify-center bg-[#6791d1] font-medium text-[#fafafa]">
+          <%= link_to review_cards_path(id: @previous_card.id), class: 'h-full w-full flex items-center justify-center px-6 text-sm' do %>
+            <span><i class="fa-solid fa-angle-left"></i> 前のフレーズへ</span>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+    <div class="w-40">
+      <% if @next_card %>
+        <div class="next-page previous-page inline-flex h-8 w-full items-center justify-center bg-[#6791d1] font-medium text-[#fafafa]">
+          <%= link_to review_cards_path(id: @next_card.id), class: 'h-full w-full flex items-center justify-center px-6 text-sm' do %>
+            <span>次のフレーズへ <i class="fa-solid fa-angle-right"></i></span>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+  </div>
 </div>
-

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -6,3 +6,4 @@ pin '@hotwired/stimulus', to: 'stimulus.min.js'
 pin '@hotwired/stimulus-loading', to: 'stimulus-loading.js'
 pin_all_from 'app/javascript/controllers', under: 'controllers'
 pin 'tailwindcss-stimulus-components' # @6.1.3
+pin 'fontawesome', to: 'https://kit.fontawesome.com/aa92689c14.js', preload: true

--- a/spec/system/cards_spec.rb
+++ b/spec/system/cards_spec.rb
@@ -77,15 +77,15 @@ RSpec.describe "Cards", type: :system do
     expect(page).to have_content '復習モード'
     expect(page).to have_content 'もう少し。でも、まだ暗記できていない'
     expect(page).not_to have_content 'Almost there. But I haven\'t memorized it yet.'
-    click_on '英文を表示する'
+    click_on '英文を表示'
     expect(page).to have_content 'Almost there. But I haven\'t memorized it yet.'
     click_on '英文を隠す'
     expect(page).not_to have_content 'Almost there. But I haven\'t memorized it yet.'
-    click_on '次のカードへ'
+    click_on '次のフレーズへ'
     expect(page).to have_content '復習モード'
     expect(page).to have_content 'まだ暗記できていない'
     expect(page).not_to have_content 'I haven\'t memorized it yet.'
-    click_on '前のカードへ'
+    click_on '前のフレーズへ'
     expect(page).to have_content '復習モード'
     expect(page).to have_content 'もう少し。でも、まだ暗記できていない'
     expect(page).not_to have_content 'Almost there. But I haven\'t memorized it yet.'
@@ -106,7 +106,7 @@ RSpec.describe "Cards", type: :system do
     click_on '復習モード'
     expect(page).not_to have_content 'もう少し。でも、まだ暗記できていない'
     expect(page).to have_content 'まだ暗記できていない'
-    expect(page).not_to have_content '次のカードへ'
+    expect(page).not_to have_content '次のフレーズへ'
   end
 
   it 'can be searched incrementally', :js do


### PR DESCRIPTION
- Resolve #99 

レイアウト等の調整と併せて、復習モード中に他のユーザーのカードも閲覧できる状態になってしまっていたため修正した。
