### PR TITLE
トーストの表示位置を変更した

### DIFF
--- a/app/views/application/_flash.html.erb
+++ b/app/views/application/_flash.html.erb
@@ -1,5 +1,5 @@
 <% if notice %>
-  <div class="fixed inset-x-0 top-[30px] flex items-end justify-right px-4 py-6 sm:p-6 justify-end z-30 pointer-events-none">
+  <div class="fixed w-full top-0 mt-16 max-w-screen-md flex items-center justify-end z-50 pointer-events-none">
     <div data-controller="flash" data-flash-dismiss-after-value="3000" class="max-w-sm w-full shadow-lg rounded px-4 py-3 rounded relative bg-green-400 border-l-4 border-green-700 text-white pointer-events-auto">
       <div class="p-2">
         <div class="flex items-start">


### PR DESCRIPTION
・トーストの表示位置がスクリーンの右端になってしまっていたため`body`の右端に揃えるように変更した。