### PR TITLE
翻訳できるフレーズの文字数に制限を追加

### DIFF
--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -33,13 +33,13 @@ class CardsController < ApplicationController
       config.host = 'https://api-free.deepl.com'
     end
     original_text = card_params[:original_text]
-    inputted_lang = CLD.detect_language(original_text)
-    translation = DeepL.translate original_text, nil, inputted_lang[:code] == 'ja' ? 'EN' : 'JA'
+    input_lang = CLD.detect_language(original_text)[:code]
+    translation = DeepL.translate original_text, nil, input_lang == 'ja' ? 'EN' : 'JA'
 
-    if inputted_lang[:code] == 'ja'
-      @card = current_user.cards.build(ja_phrase: original_text, en_phrase: translation)
+    if input_lang == 'ja'
+      @card = current_user.cards.build(ja_phrase: original_text, en_phrase: translation, input_lang:)
     else
-      @card = current_user.cards.build(ja_phrase: translation, en_phrase: original_text)
+      @card = current_user.cards.build(ja_phrase: translation, en_phrase: original_text, input_lang:)
     end
 
     if @card.save

--- a/app/models/card.rb
+++ b/app/models/card.rb
@@ -1,9 +1,11 @@
 class Card < ApplicationRecord
+  attr_accessor :input_lang
   belongs_to :user
 
-  validates :ja_phrase, presence: true
+  validates :ja_phrase, presence: true, uniqueness: { scope: :en_phrase }
+  validates :ja_phrase, length: { maximum: 100 }, if: ->(card) { card.input_lang == 'ja' }
   validates :en_phrase, presence: true
-  validates :ja_phrase, uniqueness: { scope: :en_phrase }
+  validates :en_phrase, length: { maximum: 200 }, if: ->(card) { card.input_lang == 'en' }
 
   scope :memorized, -> { where.not(memorized_at: nil) }
   scope :unmemorized, -> { where(memorized_at: nil) }

--- a/app/views/cards/_form.html.erb
+++ b/app/views/cards/_form.html.erb
@@ -12,6 +12,9 @@
       <% @card.errors.full_messages_for(:ja_phrase).each do |message| %>
         <div class="text-red-500"><%= message %></div>
       <% end %>
+      <% @card.errors.full_messages_for(:en_phrase).each do |message| %>
+        <div class="text-red-500"><%= message %></div>
+      <% end %>
       <div class="form-buttons grid justify-items-center">
         <div class="w-full h-full flex items-center flex flex-col">
           <div class="submit-button w-1/2 mt-2 mb-2 grid justify-items-center rounded-full border border-gray-500 bg-[#21cbca] text-[#fafafa]">


### PR DESCRIPTION
- Resolve #72 

- 日本語は100文字、英語は200文字まで入力できるように設定した。文字数に差があるのは、同じ文字数であれば日本語のほうが英語に比べて倍近い意味を表現できるため。（X（旧Twitter）においても、日本語は140文字、英語は280文字を上限に設定している。）

- また、翻訳結果についてはユーザーが文字数を調整できないにも関わらず、APIからの返り値が文字数制限に引っかかってしまうとユーザーに落ち度がなくてもカードを作成できないことになってしまうため、APIの返り値が入るほうのカラムについてはバリデーションを無効にするよう条件を指定している。